### PR TITLE
[tab]: Update Tab.ListItem type to use ReactNode as children

### DIFF
--- a/packages/tab/src/index.d.ts
+++ b/packages/tab/src/index.d.ts
@@ -13,7 +13,7 @@ type List = FunctionComponent<ListProps & Styling>
 export interface ListItemProps {
     id: string | number
     active?: boolean
-    children?: string
+    children?: React.ReactNode
     onClick?: (i: number, event: MouseEvent) => void
 }
 interface ListItemAnchorProps {


### PR DESCRIPTION
By making it a string typescript was not allowing the following content:

```
My items (50)
```

where 50 is a `number`. By changing it to `React.ReactNode`, that case is fixed and we now match the standard `PropsWithChildren` type in React:

```typescript
type PropsWithChildren<P> = P & { children?: ReactNode };
```

I also don't think this change is incompatible with the implementation since `children` are passed through untouched afaict:

https://github.com/pluralsight/design-system/blob/dcf5395bee91dc24cd03e74dbcd100d30fa8025e/packages/tab/src/react/list-item.js#L47
